### PR TITLE
Docker build other platform images

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -38,5 +38,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: 'chrishubert/whatsapp-web-api:latest'


### PR DESCRIPTION
 PR allows docker to build other platform images. Should solve https://github.com/chrishubert/whatsapp-api/issues/44 in a right way.