### PR TITLE
Bump whatsapp-web.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "qr-image": "^3.2.0",
         "qrcode-terminal": "^0.12.0",
         "swagger-ui-express": "^4.6.3",
-        "whatsapp-web.js": "https://github.com/Julzk/whatsapp-web.js/tarball/jkr_hotfix_8"
+        "whatsapp-web.js": "^1.22.2-alpha.1"
       },
       "devDependencies": {
         "eslint": "^8.38.0",
@@ -7089,10 +7089,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatsapp-web.js": {
-      "version": "1.21.1-alpha.1",
-      "resolved": "https://github.com/Julzk/whatsapp-web.js/tarball/jkr_hotfix_8",
-      "integrity": "sha512-qVyt6GsOKZhplZ0I/+JFb+nqqkezkiWKevjttsvuwOKHuwdHDlrq2NrYUvfRvXx++GNrN8kQmQiQqvcuO5HeyQ==",
-      "license": "Apache-2.0",
+      "version": "1.22.2-alpha.1",
+      "resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.22.2-alpha.1.tgz",
+      "integrity": "sha512-E3fLtkybS/t1cYEIRtnsqwYrvIOsZz5odHFHvdZPxnQFdTvsf/rb6iSc9W2KQmhHxLU3YdNankvOBabmMc3Qnw==",
       "dependencies": {
         "@pedroslopez/moduleraid": "^5.0.2",
         "fluent-ffmpeg": "^2.1.2",
@@ -12649,8 +12648,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatsapp-web.js": {
-      "version": "https://github.com/Julzk/whatsapp-web.js/tarball/jkr_hotfix_8",
-      "integrity": "sha512-qVyt6GsOKZhplZ0I/+JFb+nqqkezkiWKevjttsvuwOKHuwdHDlrq2NrYUvfRvXx++GNrN8kQmQiQqvcuO5HeyQ==",
+      "version": "1.22.2-alpha.1",
+      "resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.22.2-alpha.1.tgz",
+      "integrity": "sha512-E3fLtkybS/t1cYEIRtnsqwYrvIOsZz5odHFHvdZPxnQFdTvsf/rb6iSc9W2KQmhHxLU3YdNankvOBabmMc3Qnw==",
       "requires": {
         "@pedroslopez/moduleraid": "^5.0.2",
         "archiver": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "qr-image": "^3.2.0",
     "qrcode-terminal": "^0.12.0",
     "swagger-ui-express": "^4.6.3",
-    "whatsapp-web.js": "https://github.com/Julzk/whatsapp-web.js/tarball/jkr_hotfix_8"
+    "whatsapp-web.js": "^1.22.2-alpha.1"
   },
   "devDependencies": {
     "eslint": "^8.38.0",


### PR DESCRIPTION
It seems like the previous fix is no longer working, so rollback to the original library