### PR TITLE
General improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,8 @@ SET_MESSAGES_AS_SEEN=TRUE # WILL MARK THE MESSAGES AS READ AUTOMATICALLY
 # ALL CALLBACKS: auth_failure|authenticated|call|change_state|disconnected|group_join|group_leave|group_update|loading_screen|media_uploaded|message|message_ack|message_create|message_reaction|message_revoke_everyone|qr|ready|contact_changed
 DISABLED_CALLBACKS=message_ack|message_reaction  # PREVENT SENDING CERTAIN TYPES OF CALLBACKS BACK TO THE WEBHOOK
 WEB_VERSION='2.2328.5' # OPTIONAL, THE VERSION OF WHATSAPP WEB TO USE
-WEB_VERSION_CACHE_TYPE='remote' # OPTIONAL, DETERMINTES WHERE TO GET THE WHATSAPP WEB VERSION, DEFAULT 'remote'
+WEB_VERSION_CACHE_TYPE=remote # OPTIONAL, DETERMINTES WHERE TO GET THE WHATSAPP WEB VERSION, DEFAULT 'none'
+RECOVER_SESSIONS=TRUE # OPTIONAL, SHOULD WE RECOVER THE SESSION IN CASE OF PAGE FAILURES
 
 ## Session File Storage ##
 SESSIONS_PATH=./sessions # OPTIONAL

--- a/src/config.js
+++ b/src/config.js
@@ -3,17 +3,18 @@ require('dotenv').config()
 
 // setup global const
 const sessionFolderPath = process.env.SESSIONS_PATH || './sessions'
-const enableLocalCallbackExample = process.env.ENABLE_LOCAL_CALLBACK_EXAMPLE === 'TRUE'
+const enableLocalCallbackExample = (process.env.ENABLE_LOCAL_CALLBACK_EXAMPLE || '').toLowerCase() === 'true'
 const globalApiKey = process.env.API_KEY
 const baseWebhookURL = process.env.BASE_WEBHOOK_URL
 const maxAttachmentSize = parseInt(process.env.MAX_ATTACHMENT_SIZE) || 10000000
-const setMessagesAsSeen = process.env.SET_MESSAGES_AS_SEEN === 'TRUE'
+const setMessagesAsSeen = (process.env.SET_MESSAGES_AS_SEEN || '').toLowerCase() === 'true'
 const disabledCallbacks = process.env.DISABLED_CALLBACKS ? process.env.DISABLED_CALLBACKS.split('|') : []
-const enableSwaggerEndpoint = process.env.ENABLE_SWAGGER_ENDPOINT === 'TRUE'
+const enableSwaggerEndpoint = (process.env.ENABLE_SWAGGER_ENDPOINT || '').toLowerCase() === 'true'
 const webVersion = process.env.WEB_VERSION
-const webVersionCacheType = process.env.WEB_VERSION_CACHE_TYPE || 'remote'
+const webVersionCacheType = process.env.WEB_VERSION_CACHE_TYPE || 'none'
 const rateLimitMax = process.env.RATE_LIMIT_MAX || 1000
 const rateLimitWindowMs = process.env.RATE_LIMIT_WINDOW_MS || 1000
+const recoverSessions = (process.env.RECOVER_SESSIONS || '').toLowerCase() === 'true'
 
 module.exports = {
   sessionFolderPath,
@@ -27,5 +28,6 @@ module.exports = {
   webVersion,
   webVersionCacheType,
   rateLimitMax,
-  rateLimitWindowMs
+  rateLimitWindowMs,
+  recoverSessions
 }

--- a/src/controllers/sessionController.js
+++ b/src/controllers/sessionController.js
@@ -209,6 +209,9 @@ const terminateSession = async (req, res) => {
   try {
     const sessionId = req.params.sessionId
     const validation = await validateSession(sessionId)
+    if (validation.message === 'session_not_found') {
+      return res.json(validation)
+    }
     await deleteSession(sessionId, validation)
     /* #swagger.responses[200] = {
       description: "Sessions terminated.",

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -90,7 +90,7 @@ const setupSession = (sessionId) => {
     const clientOptions = {
       puppeteer: {
         executablePath: process.env.CHROME_BIN || null,
-        headless: false,
+        // headless: false,
         args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
       },
       userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36',

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -1,7 +1,7 @@
 const { Client, LocalAuth } = require('whatsapp-web.js')
 const fs = require('fs')
 const sessions = new Map()
-const { baseWebhookURL, sessionFolderPath, maxAttachmentSize, setMessagesAsSeen, webVersion, webVersionCacheType } = require('./config')
+const { baseWebhookURL, sessionFolderPath, maxAttachmentSize, setMessagesAsSeen, webVersion, webVersionCacheType, recoverSessions } = require('./config')
 const { triggerWebhook, waitForNestedObject, checkIfEventisEnabled } = require('./utils')
 
 // Function to validate if the session is ready
@@ -93,7 +93,7 @@ const setupSession = (sessionId) => {
         headless: false,
         args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
       },
-      userAgent: 'Mozilla/5.0 (X11 Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36',
+      userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36',
       authStrategy: localAuth
     }
 
@@ -136,22 +136,25 @@ const initializeEvents = (client, sessionId) => {
   // check if the session webhook is overridden
   const sessionWebhook = process.env[sessionId.toUpperCase() + '_WEBHOOK_URL'] || baseWebhookURL
 
-  waitForNestedObject(client, 'pupPage').then(() => {
-    client.pupPage.on('close', async function () {
-      // emitted when the page closes
-      console.log(`Browser page closed ${sessionId}`)
-      sessions.delete(sessionId)
-      await client.destroy()
-      setupSession(sessionId)
-    })
-    client.pupPage.on('error', async function (error) {
-      // emitted when the page crashes. Will contain an `Error`
-      console.log(`Error occurred on browser page ${sessionId}`, error)
-      sessions.delete(sessionId)
-      await client.destroy()
-      setupSession(sessionId)
-    })
-  }).catch(e => {})
+  if (recoverSessions) {
+    waitForNestedObject(client, 'pupPage').then(() => {
+      const restartSession = async (sessionId) => {
+        sessions.delete(sessionId)
+        await client.destroy().catch(e => {})
+        setupSession(sessionId)
+      }
+      client.pupPage.once('close', function () {
+        // emitted when the page closes
+        console.log(`Browser page closed for ${sessionId}. Restoring`)
+        restartSession(sessionId)
+      })
+      client.pupPage.once('error', function () {
+        // emitted when the page crashes
+        console.log(`Error occurred on browser page for ${sessionId}. Restoring`)
+        restartSession(sessionId)
+      })
+    }).catch(e => {})
+  }
 
   checkIfEventisEnabled('auth_failure')
     .then(_ => {
@@ -324,6 +327,11 @@ const deleteSessionFolder = async (sessionId) => {
 const deleteSession = async (sessionId, validation) => {
   try {
     const client = sessions.get(sessionId)
+    if (!client) {
+      return
+    }
+    client.pupPage.removeAllListeners('close')
+    client.pupPage.removeAllListeners('error')
     if (validation.success) {
       // Client Connected, request logout
       console.log(`Logging out session ${sessionId}`)


### PR DESCRIPTION
- restart the session if error on page occurred or page/browser closed(optional parameter) 
- do not wait forever in case the page is closed
- disable webVersion cache by default
- bump userAgent
- case insensitive environment variables 

Also this solves https://github.com/chrishubert/whatsapp-api/issues/96